### PR TITLE
Xarray Tutorial notebook now installs a more updated version of numpy

### DIFF
--- a/Tutorial/11-Xarray.ipynb
+++ b/Tutorial/11-Xarray.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "id": "3a9d3fd9-e9db-44da-a335-d4e76443da95",
    "metadata": {},
    "outputs": [
@@ -32,22 +32,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: h5netcdf in /opt/conda/lib/python3.9/site-packages (0.13.1)\n",
-      "Requirement already satisfied: h5py in /opt/conda/lib/python3.9/site-packages (from h5netcdf) (3.2.1)\n",
-      "Requirement already satisfied: packaging in /opt/conda/lib/python3.9/site-packages (from h5netcdf) (20.9)\n",
-      "Requirement already satisfied: numpy>=1.19.0 in /opt/conda/lib/python3.9/site-packages (from h5py->h5netcdf) (1.20.2)\n",
-      "Requirement already satisfied: pyparsing>=2.0.2 in /opt/conda/lib/python3.9/site-packages (from packaging->h5netcdf) (2.4.7)\n"
+      "Collecting h5netcdf\n",
+      "  Downloading h5netcdf-1.1.0-py2.py3-none-any.whl (26 kB)\n",
+      "Requirement already satisfied: h5py in /home/matthewlarson/Documents/anaconda3/lib/python3.9/site-packages (from h5netcdf) (3.7.0)\n",
+      "Requirement already satisfied: packaging in /home/matthewlarson/Documents/anaconda3/lib/python3.9/site-packages (from h5netcdf) (21.3)\n",
+      "Requirement already satisfied: numpy>=1.14.5 in /home/matthewlarson/Documents/anaconda3/lib/python3.9/site-packages (from h5py->h5netcdf) (1.21.5)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /home/matthewlarson/Documents/anaconda3/lib/python3.9/site-packages (from packaging->h5netcdf) (3.0.9)\n",
+      "Installing collected packages: h5netcdf\n",
+      "Successfully installed h5netcdf-1.1.0\n"
      ]
     }
    ],
    "source": [
     "# h5netcdf package not pre-installed, so install here\n",
-    "! pip install h5netcdf"
+    "! pip install h5netcdf\n",
+    "# numpy versions below 1.21 will cause issues with importing xarray\n",
+    "# You may need to restart the kernel after running this cell\n",
+    "!pip install numpy==1.21.6"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "1b993703-2a25-4d1d-bdae-092a5a232520",
    "metadata": {},
    "outputs": [],
@@ -2017,7 +2023,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2031,7 +2037,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes a TypeError caused when importing Xarray with numpy 1.20.3

Specifically, the error was
`TypeError: <class 'numpy.typing._dtype_like._SupportsDType'> is not a generic class`